### PR TITLE
fix: mempool full retry logic

### DIFF
--- a/relayer/chains/wasm/tx.go
+++ b/relayer/chains/wasm/tx.go
@@ -837,10 +837,10 @@ func (ap *WasmProvider) SendMessagesToMempool(
 		if msg.Type() == MethodUpdateClient {
 			if err := retry.Do(func() error {
 				if err := ap.BroadcastTx(cliCtx, txBytes, []provider.RelayerMessage{msg}, asyncCtx, defaultBroadcastWaitTimeout, asyncCallback, true); err != nil {
+					ap.log.Error("Failed to update client", zap.Any("Message", msg), zap.Error(err))
 					if strings.Contains(err.Error(), sdkerrors.ErrWrongSequence.Error()) {
 						ap.handleAccountSequenceMismatchError(err)
 					}
-					ap.log.Error("Failed to update client", zap.Any("Message", msg), zap.Error(err))
 				}
 				return err
 			}, retry.Context(ctx), retry.Attempts(0), specialDel, rtyErr); err != nil {

--- a/relayer/chains/wasm/tx.go
+++ b/relayer/chains/wasm/tx.go
@@ -52,7 +52,7 @@ var (
 	rtyAttNum                   = uint(5)
 	rtyAtt                      = retry.Attempts(rtyAttNum)
 	rtyDel                      = retry.Delay(time.Millisecond * 400)
-	memPoolDel                  = retry.Delay(time.Second * 30)
+	specialDel                  = retry.Delay(time.Second * 30)
 	rtyErr                      = retry.LastErrorOnly(true)
 	numRegex                    = regexp.MustCompile("[0-9]+")
 	defaultBroadcastWaitTimeout = 10 * time.Minute
@@ -835,20 +835,14 @@ func (ap *WasmProvider) SendMessagesToMempool(
 		}
 
 		if msg.Type() == MethodUpdateClient {
-			delay := retry.Delay(time.Millisecond * time.Duration(ap.PCfg.BlockInterval))
-			retryAttempt := rtyAtt
 			if err := retry.Do(func() error {
 				if err := ap.BroadcastTx(cliCtx, txBytes, []provider.RelayerMessage{msg}, asyncCtx, defaultBroadcastWaitTimeout, asyncCallback, true); err != nil {
 					if strings.Contains(err.Error(), sdkerrors.ErrWrongSequence.Error()) {
 						ap.handleAccountSequenceMismatchError(err)
-					} else if strings.Contains(err.Error(), sdkerrors.ErrMempoolIsFull.Error()) {
-						ap.log.Info("Mempool is full, retrying later with increased delay")
-						delay = memPoolDel
-						retryAttempt = retry.Attempts(0)
 					}
 				}
 				return err
-			}, retry.Context(ctx), retryAttempt, delay, rtyErr); err != nil {
+			}, retry.Context(ctx), retry.Attempts(0), specialDel, rtyErr); err != nil {
 				ap.log.Error("Failed to update client", zap.Any("Message", msg))
 				return err
 			}

--- a/relayer/chains/wasm/tx.go
+++ b/relayer/chains/wasm/tx.go
@@ -840,6 +840,7 @@ func (ap *WasmProvider) SendMessagesToMempool(
 					if strings.Contains(err.Error(), sdkerrors.ErrWrongSequence.Error()) {
 						ap.handleAccountSequenceMismatchError(err)
 					}
+					ap.log.Error("Failed to update client", zap.Any("Message", msg), zap.Error(err))
 				}
 				return err
 			}, retry.Context(ctx), retry.Attempts(0), specialDel, rtyErr); err != nil {


### PR DESCRIPTION
This pull request fixes the issue with the mempool full retry logic. The previous implementation was not handling the retry correctly, causing errors when the mempool was full. This fix ensures that the retry logic works as expected and handles the mempool full scenario properly.