### PR TITLE
feat: added range tx search when applicable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --update --no-cache make git musl-dev gcc binutils-gold cargo
 
 ARG BUILDPLATFORM=arm64
 ARG TARGETPLATFORM=arm64
-ARG COSMWASM_VERSION=1.2.3
+ARG COSMWASM_VERSION=1.5.0
 
 RUN wget https://github.com/CosmWasm/wasmvm/releases/download/v${COSMWASM_VERSION}/libwasmvm_muslc.aarch64.a -O /usr/lib/libwasmvm.aarch64.a && \
     wget https://github.com/CosmWasm/wasmvm/releases/download/v${COSMWASM_VERSION}/libwasmvm_muslc.x86_64.a -O /usr/lib/libwasmvm.x86_64.a
@@ -50,7 +50,7 @@ RUN ln sh pwd && \
     rm ln rm
 
 # Install chain binaries
-COPY --from=build-env /bin/rly /bin
+COPY --from=build-env /go/bin/rly /bin
 
 # Install trusted CA certificates
 COPY --from=busybox-min /etc/ssl/cert.pem /etc/ssl/cert.pem

--- a/relayer/chains/icon/icon_chain_processor.go
+++ b/relayer/chains/icon/icon_chain_processor.go
@@ -671,6 +671,10 @@ func (icp *IconChainProcessor) handlePathProcessorUpdate(ctx context.Context,
 
 	if latestHeight != 0 && uint64(latestHeight)-latestHeader.Height() < 3 {
 		inSync = true
+		if !icp.inSync {
+			icp.inSync = true
+			icp.log.Info("Chain is in sync")
+		}
 	}
 
 	for _, pp := range icp.pathProcessors {

--- a/relayer/chains/wasm/provider.go
+++ b/relayer/chains/wasm/provider.go
@@ -355,7 +355,7 @@ func (ap *WasmProvider) Init(ctx context.Context) error {
 	ap.rangeSupport = false
 	_, err = rpcClient.TxSearch(ctx, "execute._contract_address='invalid' AND tx.height>=38769995", true, &page, &page, "asc")
 	if err != nil && strings.Contains(err.Error(), "strict equality") {
-		fmt.Println("given RPC doesn't Supports range queries")
+		ap.log.Info("given RPC doesn't Supports range queries")
 	} else {
 		ap.rangeSupport = true
 	}

--- a/relayer/chains/wasm/tx.go
+++ b/relayer/chains/wasm/tx.go
@@ -1309,17 +1309,15 @@ func parseEventsFromTxResponse(resp *sdk.TxResponse) []provider.RelayerEvent {
 		return events
 	}
 
-	for _, logs := range resp.Logs {
-		for _, event := range logs.Events {
-			attributes := make(map[string]string)
-			for _, attribute := range event.Attributes {
-				attributes[attribute.Key] = attribute.Value
-			}
-			events = append(events, provider.RelayerEvent{
-				EventType:  event.Type,
-				Attributes: attributes,
-			})
+	for _, event := range resp.Events {
+		attributes := make(map[string]string)
+		for _, attribute := range event.Attributes {
+			attributes[attribute.Key] = attribute.Value
 		}
+		events = append(events, provider.RelayerEvent{
+			EventType:  event.Type,
+			Attributes: attributes,
+		})
 	}
 	return events
 }

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -396,6 +396,9 @@ func (ccp *WasmChainProcessor) shouldSkipProcessBlock(blocks []int64, block int6
 }
 
 func findMaxBlock(blocks []int64) int64 {
+	if len(blocks) == 0 {
+		return 0
+	}
 	return blocks[len(blocks)-1]
 }
 

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -466,6 +466,14 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 	heighttoSync := syncUpHeight()
 	delta := persistence.latestHeight - persistence.latestQueriedBlock
 	if ccp.chainProvider.rangeSupport && delta > 20 {
+		status, err := ccp.chainProvider.BlockRPCClient.Status(ctx)
+		if err != nil {
+			return nil
+		}
+		if persistence.latestQueriedBlock > status.SyncInfo.LatestBlockHeight &&
+			persistence.latestHeight > status.SyncInfo.LatestBlockHeight {
+			persistence.latestHeight = status.SyncInfo.LatestBlockHeight
+		}
 		if (persistence.latestQueriedBlock + 1) >= persistence.latestHeight {
 			return nil
 		}

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -454,7 +454,7 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 
 	syncUpHeight := func() int64 {
 		if ccp.chainProvider.rangeSupport {
-			return persistence.latestHeight - inSyncNumBlocksThreshold + 1
+			return persistence.latestHeight - inSyncNumBlocksThreshold + 2
 		}
 		if persistence.latestHeight-persistence.latestQueriedBlock > MaxBlockFetch {
 			return persistence.latestQueriedBlock + MaxBlockFetch

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -634,14 +634,6 @@ func (ccp *WasmChainProcessor) Verify(ctx context.Context, untrusted *types.Ligh
 		return fmt.Errorf("failed to verify Header: %v", err)
 	}
 
-	if !bytes.Equal(untrusted.Header.ValidatorsHash, ccp.verifier.Header.NextValidatorsHash) {
-		err := fmt.Errorf("expected old header next validators (%X) to match those from new header (%X)",
-			ccp.verifier.Header.NextValidatorsHash,
-			untrusted.Header.ValidatorsHash,
-		)
-		return err
-	}
-
 	// Ensure that +2/3 of new validators signed correctly.
 	if err := untrusted.ValidatorSet.VerifyCommitLight(ccp.verifier.Header.ChainID, untrusted.Commit.BlockID,
 		untrusted.Header.Height, untrusted.Commit); err != nil {

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -80,6 +80,10 @@ func NewWasmChainProcessor(log *zap.Logger, provider *WasmProvider, metrics *pro
 	}
 }
 
+var (
+	inSyncNumBlocksThreshold = int64(2)
+)
+
 const (
 	queryTimeout                = 5 * time.Second
 	blockResultsQueryTimeout    = 2 * time.Minute
@@ -89,8 +93,8 @@ const (
 	// TODO: review transfer to providerConfig
 	defaultMinQueryLoopDuration      = 1 * time.Second
 	defaultBalanceUpdateWaitDuration = 60 * time.Second
-	inSyncNumBlocksThreshold         = 2
-	MaxBlockFetch                    = 100
+
+	MaxBlockFetch = 100
 )
 
 // latestClientState is a map of clientID to the latest clientInfo for that client.
@@ -281,14 +285,13 @@ func (ccp *WasmChainProcessor) Run(ctx context.Context, initialBlockHistory uint
 	}
 
 	ccp.log.Debug("Entering Wasm main query loop")
-
+	if ccp.chainProvider.rangeSupport {
+		inSyncNumBlocksThreshold = 5
+	}
 	ticker := time.NewTicker(persistence.minQueryLoopDuration)
 	defer ticker.Stop()
-
 	for {
-		if err := ccp.queryCycle(ctx, &persistence); err != nil {
-			return err
-		}
+
 		select {
 		case <-ctx.Done():
 			return nil
@@ -296,6 +299,9 @@ func (ccp *WasmChainProcessor) Run(ctx context.Context, initialBlockHistory uint
 			ccp.SnapshotHeight(ccp.getHeightToSave(persistence.latestHeight))
 		case <-ticker.C:
 			ticker.Reset(persistence.minQueryLoopDuration)
+			if err := ccp.queryCycle(ctx, &persistence); err != nil {
+				return err
+			}
 		}
 	}
 }
@@ -358,6 +364,47 @@ func (ccp *WasmChainProcessor) initializeChannelState(ctx context.Context) error
 	return nil
 }
 
+func (ccp *WasmChainProcessor) getBlocksToProcess(ctx context.Context, blockToRequest int64) ([]int64, error) {
+	ibcHandlerAddr := ccp.chainProvider.PCfg.IbcHandlerAddress
+	queryFilter := fmt.Sprintf("tx.height>%d AND execute._contract_address='%s'",
+		blockToRequest, ibcHandlerAddr)
+	queryCtx, cancelQueryCtx := context.WithTimeout(ctx, blockResultsQueryTimeout)
+	defer cancelQueryCtx()
+	page := int(1)
+	perPage := int(50)
+	txsResult, err := ccp.chainProvider.RPCClient.TxSearch(queryCtx, queryFilter, true, &page, &perPage, "asc")
+	var resultArr []int64
+	if err != nil {
+		return []int64{}, err
+	}
+	for _, tx := range txsResult.Txs {
+		resultArr = append(resultArr, tx.Height)
+	}
+	return resultArr, nil
+}
+
+func (ccp *WasmChainProcessor) shouldSkipProcessBlock(blocks []int64, block int64) bool {
+	if !ccp.chainProvider.rangeSupport || len(blocks) == 0 {
+		return false
+	}
+	for _, blk := range blocks {
+		if blk == block {
+			return false
+		}
+	}
+	return true
+}
+
+func findMaxBlock(blocks []int64) int64 {
+	max := int64(0)
+	for _, blk := range blocks {
+		if max < blk {
+			max = blk
+		}
+	}
+	return max
+}
+
 func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *queryCyclePersistence) error {
 	status, err := ccp.nodeStatusWithRetry(ctx)
 	if err != nil {
@@ -392,13 +439,13 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 			ccp.log.Info("Chain is not yet in sync",
 				zap.Int64("latest_queried_block", persistence.latestQueriedBlock),
 				zap.Int64("latest_height", persistence.latestHeight),
+				zap.Int64("delta", (persistence.latestHeight-persistence.latestQueriedBlock)),
 			)
 		}
 	}
 
 	ibcMessagesCache := processor.NewIBCMessagesCache()
 	ibcHeaderCache := make(processor.IBCHeaderCache)
-
 	ppChanged := false
 
 	newLatestQueriedBlock := persistence.latestQueriedBlock
@@ -406,18 +453,48 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 	var latestHeader provider.IBCHeader
 
 	syncUpHeight := func() int64 {
+		if ccp.chainProvider.rangeSupport {
+			return persistence.latestHeight - inSyncNumBlocksThreshold + 1
+		}
 		if persistence.latestHeight-persistence.latestQueriedBlock > MaxBlockFetch {
 			return persistence.latestQueriedBlock + MaxBlockFetch
 		}
-		return persistence.latestHeight
+		return persistence.latestHeight - 1
 	}
-
-	for i := persistence.latestQueriedBlock + 1; i <= syncUpHeight(); i++ {
+	var blocks []int64
+	heighttoSync := syncUpHeight()
+	if ccp.chainProvider.rangeSupport {
+		if (persistence.latestQueriedBlock + 1) >= persistence.latestHeight {
+			return nil
+		}
+		if (persistence.latestQueriedBlock + 1) > syncUpHeight() {
+			return nil
+		}
+		blocks, err = ccp.getBlocksToProcess(ctx, persistence.latestQueriedBlock+1)
+		if err != nil {
+			ccp.log.Info("error occurred getting blocks")
+			return nil
+		}
+		maxBlock := findMaxBlock(blocks)
+		if maxBlock != 0 {
+			heighttoSync = maxBlock
+		} else {
+			persistence.latestQueriedBlock = syncUpHeight() - 1
+		}
+	}
+	for i := persistence.latestQueriedBlock + 1; i <= heighttoSync; i++ {
 		var eg errgroup.Group
 		var blockRes *ctypes.ResultBlockResults
 		var lightBlock *types.LightBlock
 		var h provider.IBCHeader
 		i := i
+		if ccp.shouldSkipProcessBlock(blocks, i) {
+			newLatestQueriedBlock = i
+			ccp.log.Debug("Skipping block", zap.Any("height", i),
+				zap.Any("last_height", persistence.latestQueriedBlock),
+				zap.Any("blocks", blocks))
+			continue
+		}
 		eg.Go(func() (err error) {
 			queryCtx, cancelQueryCtx := context.WithTimeout(ctx, blockResultsQueryTimeout)
 			defer cancelQueryCtx()
@@ -469,18 +546,18 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 			messages := ibcMessagesFromEvents(ccp.log, tx.Events, chainID, heightUint64, ccp.chainProvider.PCfg.IbcHandlerAddress, base64Encoded)
 
 			for _, m := range messages {
-				ccp.log.Info("Detected eventlog", zap.String("eventlog", m.eventType), zap.Uint64("height", heightUint64))
+				ccp.log.Info("Detected eventlog", zap.String("eventlog", m.eventType),
+					zap.Uint64("height", heightUint64))
 				ccp.handleMessage(ctx, m, ibcMessagesCache)
 			}
 		}
 
 		newLatestQueriedBlock = i
 	}
-
 	if newLatestQueriedBlock == persistence.latestQueriedBlock {
 		return nil
 	}
-
+	persistence.latestQueriedBlock = newLatestQueriedBlock
 	if !ppChanged {
 		if firstTimeInSync {
 			for _, pp := range ccp.pathProcessors {
@@ -513,8 +590,6 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 			IBCHeaderCache:       ibcHeaderCache.Clone(),
 		})
 	}
-
-	persistence.latestQueriedBlock = newLatestQueriedBlock
 
 	return nil
 }
@@ -552,10 +627,6 @@ func (ccp *WasmChainProcessor) CurrentBlockHeight(ctx context.Context, persisten
 
 func (ccp *WasmChainProcessor) Verify(ctx context.Context, untrusted *types.LightBlock) error {
 
-	if untrusted.Height != ccp.verifier.Header.Height+1 {
-		return errors.New("headers must be adjacent in height")
-	}
-
 	if err := verifyNewHeaderAndVals(untrusted.SignedHeader,
 		untrusted.ValidatorSet,
 		ccp.verifier.Header.SignedHeader,
@@ -565,14 +636,6 @@ func (ccp *WasmChainProcessor) Verify(ctx context.Context, untrusted *types.Ligh
 
 	if !bytes.Equal(untrusted.Header.ValidatorsHash, ccp.verifier.Header.NextValidatorsHash) {
 		err := fmt.Errorf("expected old header next validators (%X) to match those from new header (%X)",
-			ccp.verifier.Header.NextValidatorsHash,
-			untrusted.Header.ValidatorsHash,
-		)
-		return err
-	}
-
-	if !bytes.Equal(untrusted.Header.LastBlockID.Hash.Bytes(), ccp.verifier.Header.Commit.BlockID.Hash.Bytes()) {
-		err := fmt.Errorf("expected LastBlockId Hash (%X) of current header  to match those from trusted Header BlockID hash (%X)",
 			ccp.verifier.Header.NextValidatorsHash,
 			untrusted.Header.ValidatorsHash,
 		)

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -567,14 +567,14 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 	if newLatestQueriedBlock == persistence.latestQueriedBlock {
 		return nil
 	}
-	persistence.latestQueriedBlock = newLatestQueriedBlock
+
 	if !ppChanged {
 		if firstTimeInSync {
 			for _, pp := range ccp.pathProcessors {
 				pp.ProcessBacklogIfReady()
 			}
 		}
-
+		persistence.latestQueriedBlock = newLatestQueriedBlock
 		return nil
 	}
 
@@ -599,7 +599,7 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 			IBCHeaderCache:       ibcHeaderCache.Clone(),
 		})
 	}
-
+	persistence.latestQueriedBlock = newLatestQueriedBlock
 	return nil
 }
 

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -89,9 +89,7 @@ const (
 	queryTimeout                = 5 * time.Second
 	blockResultsQueryTimeout    = 2 * time.Minute
 	latestHeightQueryRetryDelay = 1 * time.Second
-	clientStateQueryRetryDelay  = 1 * time.Second
 	latestHeightQueryRetries    = 5
-	clientStateQueryRetries     = 5
 
 	// TODO: review transfer to providerConfig
 	defaultMinQueryLoopDuration      = 1 * time.Second
@@ -563,7 +561,6 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 				ccp.handleMessage(ctx, m, ibcMessagesCache)
 			}
 		}
-
 		newLatestQueriedBlock = i
 	}
 	if newLatestQueriedBlock == persistence.latestQueriedBlock {
@@ -581,30 +578,15 @@ func (ccp *WasmChainProcessor) queryCycle(ctx context.Context, persistence *quer
 	}
 
 	for _, pp := range ccp.pathProcessors {
-		var clientState provider.ClientState
-		var clientID string
-		retry.Do(func() error {
-			clientID = pp.RelevantClientID(chainID)
-			clientState, err = ccp.clientState(ctx, clientID)
-			return err
-		}, retry.Context(ctx), retry.Attempts(clientStateQueryRetries),
-			retry.Delay(clientStateQueryRetryDelay),
-			retry.OnRetry(func(n uint, err error) {
-				ccp.log.Error(
-					"Error fetching client state",
-					zap.Uint("attempt", n+1),
-					zap.Uint("max_attempts", clientStateQueryRetries),
-					zap.Error(err),
-				)
-			}))
-		if clientState.ClientID == "" {
-			ccp.log.Error(
-				"Error fetching client state after max retries",
+		clientID := pp.RelevantClientID(chainID)
+		clientState, err := ccp.clientState(ctx, clientID)
+		if err != nil {
+			ccp.log.Error("Error fetching client state",
+				zap.String("client_id", clientID),
 				zap.Int64("latest_queried_block", newLatestQueriedBlock),
 				zap.Int64("last_queried_block", persistence.latestQueriedBlock),
 				zap.Error(err),
 			)
-			continue
 		}
 
 		pp.HandleNewData(chainID, processor.ChainProcessorCacheData{

--- a/relayer/chains/wasm/wasm_chain_processor.go
+++ b/relayer/chains/wasm/wasm_chain_processor.go
@@ -371,7 +371,7 @@ func (ccp *WasmChainProcessor) initializeChannelState(ctx context.Context) error
 
 func (ccp *WasmChainProcessor) getBlocksToProcess(ctx context.Context, blockToRequest int64) ([]int64, error) {
 	ibcHandlerAddr := ccp.chainProvider.PCfg.IbcHandlerAddress
-	queryFilter := fmt.Sprintf("tx.height>%d AND execute._contract_address='%s'",
+	queryFilter := fmt.Sprintf("tx.height>=%d AND execute._contract_address='%s'",
 		blockToRequest, ibcHandlerAddr)
 	queryCtx, cancelQueryCtx := context.WithTimeout(ctx, blockResultsQueryTimeout)
 	defer cancelQueryCtx()


### PR DESCRIPTION
Added range tx search to get blocks and only sync related blocks when synchronizing
Also fixed issues to empty logs and fetching from events
fixed dockerfile and added logs for sync info.
removed many block verification as they will be verified by light clients for wasm
fixed mempool issue by returning the actual error than the other variable from another scope
added checks for cases where height was sent different by batched rpc provider

```mermaid
flowchart TD
    A[Timed Processing] -->|Get latest height and \n last procesed block| C(delta >10)
    C -->|Yes| D[Get list of blocks \ncontaining relevant updates \n using batched rpc requests]
    C -->|No| E[returm empty list \nof blocks to process]
    D --> F[individual block processor]
    E --> F
    F --> |loops through last processed block to latest max block with some offset| X{blocks to process is empty? \n or \n block in processing list ?}
    X --> |yes| Y[Process block]
    X --> |no| Z[skip block]
   ``` 